### PR TITLE
Added from_cods column to location, admin1, and admin2 HDXDSYS-734

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## (next release)
+
+Miscellaneous fixes for pipelines
+
+### Changed
+- added from\_cods column to location, admin1, and admin2
+
+
 ## 0.8.1
 
 Implemented the Food Prices subcategory.

--- a/src/hapi_schema/db_admin1.py
+++ b/src/hapi_schema/db_admin1.py
@@ -39,6 +39,9 @@ class DBAdmin1(Base):
     is_unspecified: Mapped[bool] = mapped_column(
         Boolean, server_default=text("FALSE"), nullable=False
     )
+    from_cods: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, nullable=True, server_default=text("NULL"), index=True
     )

--- a/src/hapi_schema/db_admin2.py
+++ b/src/hapi_schema/db_admin2.py
@@ -40,6 +40,9 @@ class DBAdmin2(Base):
     is_unspecified: Mapped[bool] = mapped_column(
         Boolean, server_default=text("FALSE"), nullable=False
     )
+    from_cods: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, nullable=True, server_default=text("NULL"), index=True
     )

--- a/src/hapi_schema/db_location.py
+++ b/src/hapi_schema/db_location.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     Integer,
     String,
@@ -29,6 +30,9 @@ class DBLocation(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     code: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(512), nullable=False, index=True)
+    from_cods: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, nullable=True, server_default=text("NULL"), index=True
     )

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -19,6 +19,7 @@ class DBAdmin1VAT(Base):
     code: Mapped[str] = mapped_column(String(128), index=True)
     name: Mapped[str] = mapped_column(String(512), index=True)
     is_unspecified: Mapped[bool] = mapped_column(Boolean)
+    from_cods: Mapped[bool] = mapped_column(Boolean)
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, index=True
     )
@@ -36,6 +37,7 @@ class DBAdmin2VAT(Base):
     code: Mapped[str] = mapped_column(String(128), index=True)
     name: Mapped[str] = mapped_column(String(512), index=True)
     is_unspecified: Mapped[bool] = mapped_column(Boolean)
+    from_cods: Mapped[bool] = mapped_column(Boolean)
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, nullable=True, index=True
     )
@@ -145,6 +147,7 @@ class DBLocationVAT(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     code: Mapped[str] = mapped_column(String(128), index=True)
     name: Mapped[str] = mapped_column(String(512), index=True)
+    from_cods: Mapped[bool] = mapped_column(Boolean)
     reference_period_start: Mapped[datetime] = mapped_column(
         DateTime, index=True
     )

--- a/tests/sample_data/data_admin1.py
+++ b/tests/sample_data/data_admin1.py
@@ -4,6 +4,7 @@ data_admin1 = [
         code="FOO-XXX",
         name="Unspecified",
         is_unspecified=True,
+        from_cods=False,
     ),
     dict(
         location_ref=1,

--- a/tests/sample_data/data_admin2.py
+++ b/tests/sample_data/data_admin2.py
@@ -4,18 +4,21 @@ data_admin2 = [
         code="FOO-XXX-XXX",
         name="Unspecified",
         is_unspecified=True,
+        from_cods=False,
     ),
     dict(
         admin1_ref=2,
         code="FOO-001-XXX",
         name="Unspecified",
         is_unspecified=True,
+        from_cods=False,
     ),
     dict(
         admin1_ref=3,
         code="FOO-002-XXX",
         name="Unspecified",
         is_unspecified=True,
+        from_cods=False,
     ),
     dict(
         admin1_ref=2,

--- a/tests/sample_data/data_location.py
+++ b/tests/sample_data/data_location.py
@@ -12,5 +12,6 @@ data_location = [
         name="Barovia",
         reference_period_start=datetime(2023, 1, 1),
         reference_period_end=None,
+        from_cods=False,
     ),
 ]

--- a/tests/test_admin1.py
+++ b/tests/test_admin1.py
@@ -17,6 +17,18 @@ def test_admin1_view(run_view_test):
     )
 
 
+def test_admin1_defaults(run_view_test):
+    """Check that default values are set properly."""
+    view_admin1 = Database.prepare_view(view_params_admin1.__dict__)
+    run_view_test(
+        view=view_admin1,
+        whereclause=(
+            view_admin1.c.id == 2,
+            view_admin1.c.from_cods,  # should be True
+        ),
+    )
+
+
 def test_reference_period_constraint(run_constraints_test):
     """Check that reference_period_end cannot be less than start"""
     run_constraints_test(

--- a/tests/test_admin2.py
+++ b/tests/test_admin2.py
@@ -18,6 +18,18 @@ def test_admin2_view(run_view_test):
     )
 
 
+def test_admin2_defaults(run_view_test):
+    """Check that default values are set properly."""
+    view_admin2 = Database.prepare_view(view_params_admin2.__dict__)
+    run_view_test(
+        view=view_admin2,
+        whereclause=(
+            view_admin2.c.id == 4,
+            view_admin2.c.from_cods,  # should be True
+        ),
+    )
+
+
 def test_reference_period_constraint(run_constraints_test):
     """Check that reference_period_end cannot be less than start"""
     run_constraints_test(

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -18,6 +18,18 @@ def test_location_view(run_view_test):
     )
 
 
+def test_location_defaults(run_view_test):
+    """Check that default values are set properly."""
+    view_location = Database.prepare_view(view_params_location.__dict__)
+    run_view_test(
+        view=view_location,
+        whereclause=(
+            view_location.c.id == 1,
+            view_location.c.from_cods,  # should be True
+        ),
+    )
+
+
 def test_reference_period_constraint(run_constraints_test):
     """Check that reference_period_end cannot be less than start"""
     run_constraints_test(


### PR DESCRIPTION
This change is based on a report from @b-j-mills -- we need a way for the pipelines to distinguish extra admins they've added to support source datasets from "official" ones in the CODs.