### PR TITLE
PR Rename dataset/resource field names in VAT

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.13
+
+### Fixed
+
+- Rename fields in VAT tables
+
 ## 0.8.12
 
 ### Removed

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -108,9 +108,13 @@ class DBCurrencyVAT(Base):
 
 class DBDatasetVAT(Base):
     __tablename__ = "dataset_vat"
-    hdx_id: Mapped[str] = mapped_column(String(36), primary_key=True)
-    hdx_stub: Mapped[str] = mapped_column(String(128), index=True)
-    title: Mapped[str] = mapped_column(String(1024))
+    dataset_hdx_id: Mapped[str] = mapped_column(
+        "hdx_id", String(36), primary_key=True
+    )
+    dataset_hdx_stub: Mapped[str] = mapped_column(
+        "hdx_stub", String(128), index=True
+    )
+    dataset_hdx_title: Mapped[str] = mapped_column("title", String(1024))
     hdx_provider_stub: Mapped[str] = mapped_column(String(128), index=True)
     hdx_provider_name: Mapped[str] = mapped_column(String(512), index=True)
 
@@ -429,7 +433,9 @@ class DBRefugeesVAT(Base):
 
 class DBResourceVAT(Base):
     __tablename__ = "resource_vat"
-    hdx_id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    resource_hdx_id: Mapped[str] = mapped_column(
+        "hdx_id", String(36), primary_key=True
+    )
     dataset_hdx_id: Mapped[str] = mapped_column(String(36))
     name: Mapped[str] = mapped_column(String(256))
     format: Mapped[str] = mapped_column(String(32))
@@ -438,7 +444,9 @@ class DBResourceVAT(Base):
     download_url: Mapped[str] = mapped_column(String(1024))
     hapi_updated_date: Mapped[datetime] = mapped_column(DateTime)
     dataset_hdx_stub: Mapped[str] = mapped_column(String(128), index=True)
-    dataset_title: Mapped[str] = mapped_column(String(1024))
+    dataset_hdx_title: Mapped[str] = mapped_column(
+        "dataset_title", String(1024)
+    )
     dataset_hdx_provider_stub: Mapped[str] = mapped_column(
         String(128), index=True
     )


### PR DESCRIPTION
Renaming some fields in the VAT tables that were already renamed in the views. 

This does not affect the actual schema of HAPI in any way. 