### PR TITLE
HDXDSYS-986 Remove DateTime mapping from right hand side

### DIFF
--- a/.config/pre-commit-config.yaml
+++ b/.config/pre-commit-config.yaml
@@ -1,23 +1,23 @@
 default_language_version:
-  python: python3.11
+    python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-ast
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.2
+    rev: v0.5.5
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --config, .config/ruff.toml, --fix ]
+        args: [--config, .config/ruff.toml, --fix]
       # Run the formatter.
       - id: ruff-format
-        args: [ --config, .config/ruff.toml ]
+        args: [--config, .config/ruff.toml]
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.1.38
+    rev: 0.2.31
     hooks:
       # Run the pip compile
       - id: pip-compile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,13 +16,14 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade hatch
+    - name: Install Hatch
+      uses: pypa/hatch@install
     - name: Build with hatch
       run: |
         hatch build

--- a/.github/workflows/run-python-tests.yaml
+++ b/.github/workflows/run-python-tests.yaml
@@ -34,31 +34,32 @@ jobs:
           --name postgres-container
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade hatch
-    - name: Test with hatch/pytest
-      run: |
-        hatch run test:test
-    - name: Check styling
-      if: always()
-      run: |
-        hatch run lint:style
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        junit_files: test-results.xml
-    - name: Publish in Coveralls
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests
-        format: lcov
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Test with hatch/pytest
+        run: |
+          hatch test
+      - name: Check styling
+        if: always()
+        run: |
+          hatch fmt --check
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          junit_files: test-results.xml
+      - name: Publish in Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: tests
+          format: lcov

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.15
+
+### Changes
+
+- Applied feedback from this
+  [SQLAlchemy discussion](sqlalchemy/sqlalchemy#11748)
+  to allow usage of type annotations defined in Base classes
+
 ## 0.8.14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ content-type = "text/markdown"
 Homepage = "https://github.com/OCHA-DAP/hapi-schemas"
 
 [project.optional-dependencies]
-database = ["hdx-python-database>=1.3.1"]
+database = ["hdx-python-database>=1.3.3"]
 dev = ["pre-commit"]
-test = ["hdx-python-database>=1.3.1", "psycopg[binary]", "pytest", "pytest-cov"]
+test = ["hdx-python-database>=1.3.3", "psycopg[binary]", "pytest", "pytest-cov"]
 
 #########
 # Hatch #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,25 +72,21 @@ version_scheme = "python-simplified-semver"
 
 # Tests
 
-[tool.hatch.envs.test]
+[tool.hatch.envs.hatch-test]
 features = ["test"]
 
-[tool.hatch.envs.test.scripts]
-test = """
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.12"]
+
+[tool.hatch.envs.hatch-test.scripts]
+run = """
        pytest -c .config/pytest.ini --rootdir=. --junitxml=test-results.xml \
        --cov --cov-config=.config/coveragerc --no-cov-on-fail \
        --cov-report=lcov --cov-report=term-missing
        """
 
-[[tool.hatch.envs.test.matrix]]
-python = ["3.11"]
-
-[tool.hatch.envs.lint]
-detached = true
-dependencies = ["ruff"]
-
-[tool.hatch.envs.lint.scripts]
-style = [
-  "ruff check --config .config/ruff.toml --diff {args:.}",
-  "ruff format --config .config/ruff.toml --diff {args:.}",
-]
+[tool.hatch.envs.hatch-static-analysis.scripts]
+format-check = ["ruff format --config .config/ruff.toml --check --diff {args:.}",]
+format-fix = ["ruff format --config .config/ruff.toml {args:.}",]
+lint-check = ["ruff check --config .config/ruff.toml {args:.}",]
+lint-fix = ["ruff check --config .config/ruff.toml --fix {args:.}",]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,43 +2,49 @@
 #    uv pip compile pyproject.toml --resolver=backtracking --all-extras -o requirements.txt
 cfgv==3.4.0
     # via pre-commit
-coverage==7.5.1
+coverage==7.6.1
     # via pytest-cov
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.15.4
     # via virtualenv
 greenlet==3.0.3
     # via sqlalchemy
-hdx-python-database==1.3.1
-identify==2.5.36
+hdx-python-database==1.3.3
+    # via hapi-schema (pyproject.toml)
+identify==2.6.0
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.1
     # via pytest
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.7.0
-psycopg==3.1.18
-psycopg-binary==3.1.18
+pre-commit==3.8.0
+    # via hapi-schema (pyproject.toml)
+psycopg==3.2.1
+    # via hapi-schema (pyproject.toml)
+psycopg-binary==3.2.1
     # via psycopg
-pytest==8.2.0
-    # via pytest-cov
+pytest==8.3.2
+    # via
+    #   hapi-schema (pyproject.toml)
+    #   pytest-cov
 pytest-cov==5.0.0
-pyyaml==6.0.1
+    # via hapi-schema (pyproject.toml)
+pyyaml==6.0.2
     # via pre-commit
-setuptools==69.5.1
-    # via nodeenv
-sqlalchemy==2.0.30
-    # via hdx-python-database
-typing-extensions==4.11.0
+sqlalchemy==2.0.32
+    # via
+    #   hapi-schema (pyproject.toml)
+    #   hdx-python-database
+typing-extensions==4.12.2
     # via
     #   psycopg
     #   sqlalchemy
-virtualenv==20.26.1
+virtualenv==20.26.3
     # via pre-commit

--- a/src/hapi_schema/db_admin1.py
+++ b/src/hapi_schema/db_admin1.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
-    DateTime,
     ForeignKey,
     Integer,
     String,

--- a/src/hapi_schema/db_admin1.py
+++ b/src/hapi_schema/db_admin1.py
@@ -43,10 +43,10 @@ class DBAdmin1(Base):
         Boolean, nullable=False, server_default=text("TRUE")
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
 
     location = relationship("DBLocation")

--- a/src/hapi_schema/db_admin2.py
+++ b/src/hapi_schema/db_admin2.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
-    DateTime,
     ForeignKey,
     Integer,
     String,

--- a/src/hapi_schema/db_admin2.py
+++ b/src/hapi_schema/db_admin2.py
@@ -44,10 +44,10 @@ class DBAdmin2(Base):
         Boolean, nullable=False, server_default=text("TRUE")
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
 
     admin1 = relationship("DBAdmin1")

--- a/src/hapi_schema/db_conflict_event.py
+++ b/src/hapi_schema/db_conflict_event.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     Integer,
     select,
@@ -46,9 +45,7 @@ class DBConflictEvent(Base):
     )
     events: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
     fatalities: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_conflict_event.py
+++ b/src/hapi_schema/db_conflict_event.py
@@ -47,10 +47,10 @@ class DBConflictEvent(Base):
     events: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
     fatalities: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship("DBResource")

--- a/src/hapi_schema/db_food_price.py
+++ b/src/hapi_schema/db_food_price.py
@@ -62,10 +62,10 @@ class DBFoodPrice(Base):
     )
     price: Mapped[Decimal] = mapped_column(nullable=False)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship(DBResource)

--- a/src/hapi_schema/db_food_price.py
+++ b/src/hapi_schema/db_food_price.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     String,
     select,
@@ -61,9 +60,7 @@ class DBFoodPrice(Base):
         build_enum_using_values(PriceType), primary_key=True
     )
     price: Mapped[Decimal] = mapped_column(nullable=False)
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_food_security.py
+++ b/src/hapi_schema/db_food_security.py
@@ -52,10 +52,10 @@ class DBFoodSecurity(Base):
         Float, nullable=False, index=True
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship(DBResource)

--- a/src/hapi_schema/db_food_security.py
+++ b/src/hapi_schema/db_food_security.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy import (
-    DateTime,
     Float,
     ForeignKey,
     Integer,
@@ -51,9 +50,7 @@ class DBFoodSecurity(Base):
     population_fraction_in_phase: Mapped[Decimal] = mapped_column(
         Float, nullable=False, index=True
     )
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_funding.py
+++ b/src/hapi_schema/db_funding.py
@@ -65,12 +65,10 @@ class DBFunding(Base):
     funding_pct: Mapped[Decimal] = mapped_column(nullable=False, index=True)
 
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime,
         primary_key=True,
     )
 
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime,
         nullable=True,
         server_default=text("NULL"),
     )

--- a/src/hapi_schema/db_funding.py
+++ b/src/hapi_schema/db_funding.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 
 from sqlalchemy import (
     CheckConstraint,
-    DateTime,
     ForeignKey,
     String,
     select,

--- a/src/hapi_schema/db_humanitarian_needs.py
+++ b/src/hapi_schema/db_humanitarian_needs.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     Integer,
     String,

--- a/src/hapi_schema/db_humanitarian_needs.py
+++ b/src/hapi_schema/db_humanitarian_needs.py
@@ -74,11 +74,10 @@ class DBHumanitarianNeeds(Base):
     )
     population: Mapped[int] = mapped_column(Integer, nullable=False)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime,
         primary_key=True,
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship("DBResource")

--- a/src/hapi_schema/db_location.py
+++ b/src/hapi_schema/db_location.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
-    DateTime,
     Integer,
     String,
     select,

--- a/src/hapi_schema/db_location.py
+++ b/src/hapi_schema/db_location.py
@@ -40,10 +40,10 @@ class DBLocation(Base):
         Boolean, nullable=False, server_default=text("FALSE")
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
 
 

--- a/src/hapi_schema/db_national_risk.py
+++ b/src/hapi_schema/db_national_risk.py
@@ -71,10 +71,10 @@ class DBNationalRisk(Base):
         Float, nullable=True
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship("DBResource")

--- a/src/hapi_schema/db_national_risk.py
+++ b/src/hapi_schema/db_national_risk.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 
 from sqlalchemy import (
     CheckConstraint,
-    DateTime,
     Float,
     ForeignKey,
     Integer,
@@ -70,9 +69,7 @@ class DBNationalRisk(Base):
     meta_avg_recentness_years: Mapped[Decimal] = mapped_column(
         Float, nullable=True
     )
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_operational_presence.py
+++ b/src/hapi_schema/db_operational_presence.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     ForeignKeyConstraint,
     String,
@@ -48,9 +47,7 @@ class DBOperationalPresence(Base):
     sector_code: Mapped[str] = mapped_column(
         ForeignKey("sector.code", onupdate="CASCADE"), primary_key=True
     )
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=True, server_default=text("NULL"), index=True
     )

--- a/src/hapi_schema/db_operational_presence.py
+++ b/src/hapi_schema/db_operational_presence.py
@@ -49,10 +49,10 @@ class DBOperationalPresence(Base):
         ForeignKey("sector.code", onupdate="CASCADE"), primary_key=True
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, server_default=text("NULL"), index=True
+        nullable=True, server_default=text("NULL"), index=True
     )
 
     resource = relationship("DBResource")

--- a/src/hapi_schema/db_patch.py
+++ b/src/hapi_schema/db_patch.py
@@ -3,7 +3,7 @@
 import enum
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, Integer, String, select
+from sqlalchemy import Enum, Integer, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hapi_schema.utils.base import Base
@@ -42,9 +42,7 @@ class DBPatch(Base):
     state: Mapped[StateEnum] = mapped_column(
         Enum(StateEnum), nullable=False, index=True
     )
-    execution_date: Mapped[datetime] = mapped_column(
-        nullable=True, index=True
-    )
+    execution_date: Mapped[datetime] = mapped_column(nullable=True, index=True)
 
 
 view_params_patch = ViewParams(

--- a/src/hapi_schema/db_patch.py
+++ b/src/hapi_schema/db_patch.py
@@ -28,7 +28,7 @@ class DBPatch(Base):
     commit_hash: Mapped[str] = mapped_column(
         String(48), unique=False, nullable=False
     )
-    commit_date: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    commit_date: Mapped[datetime] = mapped_column(nullable=False)
     patch_path: Mapped[str] = mapped_column(
         String(512), nullable=False, index=True
     )
@@ -43,7 +43,7 @@ class DBPatch(Base):
         Enum(StateEnum), nullable=False, index=True
     )
     execution_date: Mapped[datetime] = mapped_column(
-        DateTime, nullable=True, index=True
+        nullable=True, index=True
     )
 
 
@@ -59,10 +59,10 @@ class DBPatchVAT(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     patch_sequence_number: Mapped[int] = mapped_column(Integer, index=True)
     commit_hash: Mapped[str] = mapped_column(String(48))
-    commit_date: Mapped[datetime] = mapped_column(DateTime)
+    commit_date: Mapped[datetime] = mapped_column()
     patch_path: Mapped[str] = mapped_column(String(512), index=True)
     patch_permalink_url: Mapped[str] = mapped_column(String(1024))
     patch_target: Mapped[str] = mapped_column(String(128))
     patch_hash: Mapped[str] = mapped_column(String(48))
     state: Mapped[str] = mapped_column(String(10), index=True)
-    execution_date: Mapped[datetime] = mapped_column(DateTime, index=True)
+    execution_date: Mapped[datetime] = mapped_column(index=True)

--- a/src/hapi_schema/db_population.py
+++ b/src/hapi_schema/db_population.py
@@ -52,10 +52,10 @@ class DBPopulation(Base):
         Integer, nullable=False, index=True
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship("DBResource")

--- a/src/hapi_schema/db_population.py
+++ b/src/hapi_schema/db_population.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     Integer,
     String,

--- a/src/hapi_schema/db_poverty_rate.py
+++ b/src/hapi_schema/db_poverty_rate.py
@@ -65,10 +65,10 @@ class DBPovertyRate(Base):
         Float, nullable=False, index=False
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     resource = relationship(DBResource)

--- a/src/hapi_schema/db_poverty_rate.py
+++ b/src/hapi_schema/db_poverty_rate.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     Float,
     ForeignKey,
     String,
@@ -64,9 +63,7 @@ class DBPovertyRate(Base):
     in_severe_poverty: Mapped[float] = mapped_column(
         Float, nullable=False, index=False
     )
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_refugees.py
+++ b/src/hapi_schema/db_refugees.py
@@ -63,10 +63,10 @@ class DBRefugees(Base):
         Integer, nullable=False, index=True
     )
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, index=True
+        nullable=False, index=True
     )
 
     # resource = relationship("DBResource")

--- a/src/hapi_schema/db_refugees.py
+++ b/src/hapi_schema/db_refugees.py
@@ -6,7 +6,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    DateTime,
     ForeignKey,
     Integer,
     String,
@@ -62,9 +61,7 @@ class DBRefugees(Base):
     population: Mapped[int] = mapped_column(
         Integer, nullable=False, index=True
     )
-    reference_period_start: Mapped[datetime] = mapped_column(
-        primary_key=True
-    )
+    reference_period_start: Mapped[datetime] = mapped_column(primary_key=True)
     reference_period_end: Mapped[datetime] = mapped_column(
         nullable=False, index=True
     )

--- a/src/hapi_schema/db_resource.py
+++ b/src/hapi_schema/db_resource.py
@@ -1,4 +1,5 @@
 """Resource table and view."""
+from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
@@ -24,12 +25,12 @@ class DBResource(Base):
     )
     name: Mapped[str] = mapped_column(String(256), nullable=False)
     format: Mapped[str] = mapped_column(String(32), nullable=False)
-    update_date = mapped_column(DateTime, nullable=False)
+    update_date: Mapped[datetime] = mapped_column(nullable=False)
     is_hxl: Mapped[bool] = mapped_column(Boolean, nullable=False)
     download_url: Mapped[str] = mapped_column(
         String(1024), nullable=False, unique=True
     )
-    hapi_updated_date = mapped_column(DateTime, nullable=False)
+    hapi_updated_date: Mapped[datetime] = mapped_column(nullable=False)
     dataset = relationship("DBDataset")
 
 

--- a/src/hapi_schema/db_resource.py
+++ b/src/hapi_schema/db_resource.py
@@ -1,9 +1,9 @@
 """Resource table and view."""
+
 from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
-    DateTime,
     ForeignKey,
     String,
     select,


### PR DESCRIPTION
Changes as per feedback from SQLAlchemy discussion: https://github.com/sqlalchemy/sqlalchemy/discussions/11748 to allow usage of type annotations defined in Base classes eg. a simple definition is
```
class Base(DeclarativeBase):
    type_annotation_map = {
        datetime.datetime: DateTime,
    }
```

https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html#orm-declarative-mapped-column-type-map

(The definition I want to use in HAPI pipelines handles timezone conversion:
```
class ConversionNoTZ(TypeDecorator):
    """Convert from/to datetime with timezone from database columns that don't
    use timezone"""

    impl = DateTime
    cache_ok = True

    def process_bind_param(self, value: Optional[datetime], _):
        if value is None:
            return value
        if value.tzinfo:
            value = value.astimezone(timezone.utc)

        return value.replace(tzinfo=None)

    def process_result_value(self, value, _):
        if value is None:
            return value
        if value.tzinfo is None:
            return value.replace(tzinfo=timezone.utc)

        return value.astimezone(timezone.utc)


class Base(DeclarativeBase):
    type_annotation_map = {
        datetime: ConversionNoTZ,
    }
```
)