### PR TITLE
Refactor HAPI database to allow partial geo standardisation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population`, and `wfp_market` (and associated views, VATS, and tests)
 - renamed existing column `admin1\_name` to `provider\_admin1\_name` in `poverty\_rate` for consistency (and updated tests and VAT)
 - made `reference\_period\_start` part of the primary key for `population\_vat` (originally omitted in error)
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,14 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9 (in progress)
 
-### Summary
-
-Major refactoring to allow partial/incremental standardisation of subnational geocodes.  Added `provider\_admin1\_name` and `provider\_admin2\_name` to the primary keys of subcategory tables (and `wfp_markets`), as appropriate.
+Major refactoring to allow partial/incremental standardisation of subnational geocodes.  Added `provider\_admin1\_name` and `provider\_admin2\_name` to the primary keys of subcategory tables (and `wfp_markets`), as appropriate.  This will break existing pipelines until they add support for the new fields.
 
 ### Changed
 
-- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security` (and associated views, VATS, and tests)
 
 ## 0.8.16
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,8 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
+- renamed existing column `admin1\_name` to `provider\_admin1\_name` in `poverty\_rate` for consistency (and updated tests and VAT)
 - made `reference\_period\_start` part of the primary key for `population\_vat` (originally omitted in error)
 
 ## 0.8.16

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9 (in progress)
 
-Major refactoring to allow partial/incremental standardisation of subnational geocodes.  Added `provider\_admin1\_name` and `provider\_admin2\_name` to the primary keys of subcategory tables (and `wfp_markets`), as appropriate.  This will break existing pipelines until they add support for the new fields.
+Major refactoring to allow partial/incremental standardisation of subnational geocodes.  Added `provider\_admin1\_name` and `provider\_admin2\_name` to the primary keys of subcategory tables (except `food_price`), as appropriate.  This will break existing pipelines until they add support for the new fields.
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9 (in progress)
 
+### Summary
+
+Major refactoring to allow partial/incremental standardisation of subnational geocodes.  Added `provider\_admin1\_name` and `provider\_admin2\_name` to the primary keys of subcategory tables (and `wfp_markets`), as appropriate.
+
 ### Changed
 
-- added `provider\_admin1\_name` to `idps` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs` (and associated views, VATS, and tests)
 
 ## 0.8.16
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,8 +13,8 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence` (and associated views, VATS, and tests)
 
 ## 0.8.16
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9 (in progress)
+
+### Changed
+
+- added `provider\_admin1\_name` to `idps` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps` (and associated views, VATS, and tests)
+
 ## 0.8.16
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,9 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population`, and `wfp_market` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population`, and `wfp\_market` (and associated views, VATS, and tests)
 - renamed existing column `admin1\_name` to `provider\_admin1\_name` in `poverty\_rate` for consistency (and updated tests and VAT)
+- updated `food\_price\_view` and VAT to include `provider\_admin1\_name` and `provider\_admin2\_name` from `wfp\_market`
 - made `reference\_period\_start` part of the primary key for `population\_vat` (originally omitted in error)
 
 ## 0.8.16

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 - added `provider\_admin1\_name` and `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population`, and `wfp\_market` (and associated views, VATS, and tests)
 - renamed existing column `admin1\_name` to `provider\_admin1\_name` in `poverty\_rate` for consistency (and updated tests and VAT)
 - updated `food\_price\_view` and VAT to include `provider\_admin1\_name` and `provider\_admin2\_name` from `wfp\_market`
+- updated `poverty\_rate\_view` and VAT to include `admin1_name` from `admin1` table
 - made `reference\_period\_start` part of the primary key for `population\_vat` (originally omitted in error)
 
 ## 0.8.16

--- a/changelog.md
+++ b/changelog.md
@@ -13,8 +13,8 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event` (and associated views, VATS, and tests)
 
 ## 0.8.16
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,9 @@ Major refactoring to allow partial/incremental standardisation of subnational ge
 
 ### Changed
 
-- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security` (and associated views, VATS, and tests)
-- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security` (and associated views, VATS, and tests)
+- added `provider\_admin1\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
+- added `provider\_admin2\_name` to `idps`, `humanitarian\_needs`, `operational\_presence`, `conflict\_event`, `food_security`, `population` (and associated views, VATS, and tests)
+- made `reference\_period\_start` part of the primary key for `population\_vat` (originally omitted in error)
 
 ## 0.8.16
 

--- a/src/hapi_schema/db_conflict_event.py
+++ b/src/hapi_schema/db_conflict_event.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from sqlalchemy import (
     ForeignKey,
     Integer,
+    String,
     select,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -42,6 +43,8 @@ class DBConflictEvent(Base):
         nullable=False,
         primary_key=True,
     )
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
     event_type: Mapped[EventType] = mapped_column(
         build_enum_using_values(EventType), nullable=False, primary_key=True
     )

--- a/src/hapi_schema/db_food_price.py
+++ b/src/hapi_schema/db_food_price.py
@@ -81,6 +81,8 @@ view_params_food_price = ViewParams(
     selectable=select(
         *DBFoodPrice.__table__.columns,
         DBWFPMarket.admin2_ref.label("admin2_ref"),
+        DBWFPMarket.provider_admin1_name.label("provider_admin1_name"),
+        DBWFPMarket.provider_admin2_name.label("provider_admin2_name"),
         DBWFPMarket.name.label("market_name"),
         DBWFPMarket.lat.label("lat"),
         DBWFPMarket.lon.label("lon"),

--- a/src/hapi_schema/db_food_security.py
+++ b/src/hapi_schema/db_food_security.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    String,
     select,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -39,6 +40,8 @@ class DBFoodSecurity(Base):
     admin2_ref: Mapped[int] = mapped_column(
         ForeignKey("admin2.id", onupdate="CASCADE"), primary_key=True
     )
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
     ipc_phase: Mapped[IPCPhase] = mapped_column(
         build_enum_using_values(IPCPhase), primary_key=True
     )

--- a/src/hapi_schema/db_funding.py
+++ b/src/hapi_schema/db_funding.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.sql import null
 from sqlalchemy.sql.expression import literal
 
 from hapi_schema.db_location import DBLocation
@@ -104,10 +103,10 @@ availability_stmt_funding = (
         literal("funding").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        null().label("admin1_name"),
-        null().label("admin1_code"),
-        null().label("admin2_name"),
-        null().label("admin2_code"),
+        literal("").label("admin1_name"),
+        literal("").label("admin1_code"),
+        literal("").label("admin2_name"),
+        literal("").label("admin2_code"),
         DBResource.hapi_updated_date,
     )
     .select_from(

--- a/src/hapi_schema/db_humanitarian_needs.py
+++ b/src/hapi_schema/db_humanitarian_needs.py
@@ -50,6 +50,8 @@ class DBHumanitarianNeeds(Base):
         ForeignKey("admin2.id", onupdate="CASCADE"),
         primary_key=True,
     )
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
     gender: Mapped[Gender] = mapped_column(
         build_enum_using_values(Gender), primary_key=True
     )

--- a/src/hapi_schema/db_idps.py
+++ b/src/hapi_schema/db_idps.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
+    String,
     select,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -41,6 +42,10 @@ class DBIDPs(Base):
     admin2_ref = mapped_column(
         ForeignKey("admin2.id", onupdate="CASCADE"), primary_key=True
     )
+
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
 
     assessment_type: Mapped[DTMAssessmentType] = mapped_column(
         build_enum_using_values(DTMAssessmentType), primary_key=True

--- a/src/hapi_schema/db_national_risk.py
+++ b/src/hapi_schema/db_national_risk.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.sql import null
 from sqlalchemy.sql.expression import literal
 
 from hapi_schema.db_location import DBLocation
@@ -107,10 +106,10 @@ availability_stmt_national_risk = (
         literal("national-risk").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        null().label("admin1_name"),
-        null().label("admin1_code"),
-        null().label("admin2_name"),
-        null().label("admin2_code"),
+        literal("").label("admin1_name"),
+        literal("").label("admin1_code"),
+        literal("").label("admin2_name"),
+        literal("").label("admin2_code"),
         DBResource.hapi_updated_date,
     )
     .select_from(

--- a/src/hapi_schema/db_operational_presence.py
+++ b/src/hapi_schema/db_operational_presence.py
@@ -42,6 +42,8 @@ class DBOperationalPresence(Base):
     admin2_ref: Mapped[int] = mapped_column(
         ForeignKey("admin2.id", onupdate="CASCADE"), primary_key=True
     )
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
     # Foreign key
     org_acronym: Mapped[str] = mapped_column(String, primary_key=True)
     # Foreign key

--- a/src/hapi_schema/db_population.py
+++ b/src/hapi_schema/db_population.py
@@ -43,6 +43,8 @@ class DBPopulation(Base):
         ForeignKey("admin2.id", onupdate="CASCADE"),
         primary_key=True,
     )
+    provider_admin1_name = mapped_column(String(512), primary_key=True)
+    provider_admin2_name = mapped_column(String(512), primary_key=True)
     gender: Mapped[Gender] = mapped_column(
         build_enum_using_values(Gender), primary_key=True
     )

--- a/src/hapi_schema/db_poverty_rate.py
+++ b/src/hapi_schema/db_poverty_rate.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import CheckConstraint
-from sqlalchemy.sql import null
 from sqlalchemy.sql.expression import literal
 
 from hapi_schema.db_admin1 import DBAdmin1
@@ -110,9 +109,9 @@ availability_stmt_poverty_rate = (
         DBPovertyRate.provider_admin1_name.label(
             "admin1_name"
         ),  # fixme once we start p-coding
-        null().label("admin1_code"),  # fixme once we start p-coding
-        null().label("admin2_name"),
-        null().label("admin2_code"),
+        literal("").label("admin1_code"),  # fixme once we start p-coding
+        literal("").label("admin2_name"),
+        literal("").label("admin2_code"),
         DBResource.hapi_updated_date,
     )
     .select_from(

--- a/src/hapi_schema/db_poverty_rate.py
+++ b/src/hapi_schema/db_poverty_rate.py
@@ -48,8 +48,7 @@ class DBPovertyRate(Base):
         nullable=False,
         primary_key=True,
     )
-    # TODO temporary -- will remove in future release and use name from admin1 table
-    admin1_name: Mapped[str] = mapped_column(
+    provider_admin1_name: Mapped[str] = mapped_column(
         String(512), nullable=False, index=True, primary_key=True
     )
     mpi: Mapped[float] = mapped_column(Float, nullable=False, index=False)
@@ -108,8 +107,10 @@ availability_stmt_poverty_rate = (
         literal("poverty-rate").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        DBPovertyRate.admin1_name,  # fixme
-        DBAdmin1.code.label("admin1_code"),
+        DBPovertyRate.provider_admin1_name.label(
+            "admin1_name"
+        ),  # fixme once we start p-coding
+        null().label("admin1_code"),  # fixme once we start p-coding
         null().label("admin2_name"),
         null().label("admin2_code"),
         DBResource.hapi_updated_date,

--- a/src/hapi_schema/db_poverty_rate.py
+++ b/src/hapi_schema/db_poverty_rate.py
@@ -82,6 +82,7 @@ view_params_poverty_rate = ViewParams(
         DBLocation.name.label("location_name"),
         DBLocation.has_hrp.label("has_hrp"),
         DBLocation.in_gho.label("in_gho"),
+        DBAdmin1.name.label("admin1_name"),
         DBAdmin1.code.label("admin1_code"),
         DBAdmin1.is_unspecified.label("admin1_is_unspecified"),
         DBAdmin1.location_ref.label("location_ref"),
@@ -106,10 +107,8 @@ availability_stmt_poverty_rate = (
         literal("poverty-rate").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        DBPovertyRate.provider_admin1_name.label(
-            "admin1_name"
-        ),  # fixme once we start p-coding
-        literal("").label("admin1_code"),  # fixme once we start p-coding
+        DBAdmin1.name.label("admin1_name"),
+        DBAdmin1.code.label("admin1_code"),
         literal("").label("admin2_name"),
         literal("").label("admin2_code"),
         DBResource.hapi_updated_date,

--- a/src/hapi_schema/db_refugees.py
+++ b/src/hapi_schema/db_refugees.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.orm import Mapped, aliased, mapped_column, relationship
-from sqlalchemy.sql import null
 from sqlalchemy.sql.expression import literal
 
 from hapi_schema.db_location import DBLocation
@@ -117,10 +116,10 @@ availability_stmt_refugees = (
         literal("refugees").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        null().label("admin1_name"),
-        null().label("admin1_code"),
-        null().label("admin2_name"),
-        null().label("admin2_code"),
+        literal("").label("admin1_name"),
+        literal("").label("admin1_code"),
+        literal("").label("admin2_name"),
+        literal("").label("admin2_code"),
         DBResource.hapi_updated_date,
     )
     .select_from(

--- a/src/hapi_schema/db_returnees.py
+++ b/src/hapi_schema/db_returnees.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.orm import Mapped, aliased, mapped_column, relationship
-from sqlalchemy.sql import null
 from sqlalchemy.sql.expression import literal
 
 from hapi_schema.db_location import DBLocation
@@ -120,10 +119,10 @@ availability_stmt_returnees = (
         literal("returnees").label("subcategory"),
         DBLocation.name.label("location_name"),
         DBLocation.code.label("location_code"),
-        null().label("admin1_name"),
-        null().label("admin1_code"),
-        null().label("admin2_name"),
-        null().label("admin2_code"),
+        literal("").label("admin1_name"),
+        literal("").label("admin1_code"),
+        literal("").label("admin2_name"),
+        literal("").label("admin2_code"),
         DBResource.hapi_updated_date,
     )
     .select_from(

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -230,6 +230,12 @@ class DBHumanitarianNeedsVAT(Base):
     __tablename__ = "humanitarian_needs_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     gender: Mapped[Gender] = mapped_column(
         build_enum_using_values(Gender), primary_key=True
     )

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -179,6 +179,12 @@ class DBFoodSecurityVAT(Base):
     __tablename__ = "food_security_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     ipc_phase: Mapped[IPCPhase] = mapped_column(
         build_enum_using_values(IPCPhase), primary_key=True
     )

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -274,6 +274,12 @@ class DBIDPsVAT(Base):
     __tablename__ = "idps_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     assessment_type: Mapped[str] = mapped_column(String(32), primary_key=True)
     reporting_round: Mapped[int] = mapped_column(Integer, nullable=True)
     population: Mapped[int] = mapped_column(Integer, index=True)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -361,6 +361,12 @@ class DBOperationalPresenceVAT(Base):
     __tablename__ = "operational_presence_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     org_acronym: Mapped[str] = mapped_column(String, primary_key=True)
     org_name: Mapped[str] = mapped_column(String, primary_key=True)
     sector_code: Mapped[str] = mapped_column(String(32), primary_key=True)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -154,6 +154,8 @@ class DBFoodPriceVAT(Base):
         nullable=True,
     )
     admin2_ref: Mapped[int] = mapped_column(Integer)
+    provider_admin1_name: Mapped[str] = mapped_column(String(512), index=True)
+    provider_admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     market_name: Mapped[str] = mapped_column(String(512), index=True)
     lat: Mapped[float] = mapped_column(Float, index=True)
     lon: Mapped[float] = mapped_column(Float, index=True)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -601,6 +601,8 @@ class DBWfpMarketVAT(Base):
     __tablename__ = "wfp_market_vat"
     code: Mapped[str] = mapped_column(String(32), primary_key=True)
     admin2_ref: Mapped[int] = mapped_column(Integer)
+    provider_admin1_name: Mapped[str] = mapped_column(String(512), index=True)
+    provider_admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     name: Mapped[str] = mapped_column(String(512), index=True)
     lat: Mapped[float] = mapped_column(Float, index=True)
     lon: Mapped[float] = mapped_column(Float, index=True)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -79,6 +79,12 @@ class DBConflictEventVAT(Base):
     __tablename__ = "conflict_event_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     event_type: Mapped[EventType] = mapped_column(
         build_enum_using_values(EventType), primary_key=True
     )

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -466,8 +466,9 @@ class DBPovertyRateVAT(Base):
     __tablename__ = "poverty_rate_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin1_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
-    admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True, index=True
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512),
+        primary_key=True,
     )
     mpi: Mapped[float] = mapped_column(Float)
     headcount_ratio: Mapped[float] = mapped_column(Float)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -427,6 +427,12 @@ class DBPopulationVAT(Base):
     __tablename__ = "population_vat"
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), primary_key=True
+    )
     gender: Mapped[Gender] = mapped_column(
         build_enum_using_values(Gender), primary_key=True
     )
@@ -435,7 +441,7 @@ class DBPopulationVAT(Base):
     max_age: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
     population: Mapped[int] = mapped_column(Integer, index=True)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, index=True
+        DateTime, primary_key=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
         DateTime,

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -489,6 +489,7 @@ class DBPovertyRateVAT(Base):
     location_name: Mapped[str] = mapped_column(String(512), index=True)
     has_hrp: Mapped[bool] = mapped_column(Boolean)
     in_gho: Mapped[bool] = mapped_column(Boolean)
+    admin1_name: Mapped[str] = mapped_column(String(512))
     admin1_code: Mapped[str] = mapped_column(String(128))
     admin1_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     location_ref: Mapped[int] = mapped_column(Integer, index=True)

--- a/src/hapi_schema/db_wfp_market.py
+++ b/src/hapi_schema/db_wfp_market.py
@@ -20,6 +20,12 @@ class DBWFPMarket(Base):
         ForeignKey("admin2.id", onupdate="CASCADE"),
         nullable=False,
     )
+    provider_admin1_name: Mapped[str] = mapped_column(
+        String(512), nullable=False, index=True
+    )
+    provider_admin2_name: Mapped[str] = mapped_column(
+        String(512), nullable=False, index=True
+    )
     name: Mapped[str] = mapped_column(String(512), nullable=False, index=True)
     lat: Mapped[float] = mapped_column(Float, nullable=False, index=True)
     lon: Mapped[float] = mapped_column(Float, nullable=False, index=True)

--- a/tests/sample_data/data_conflict_event.py
+++ b/tests/sample_data/data_conflict_event.py
@@ -4,6 +4,8 @@ data_conflict_event = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         event_type="political_violence",
         events=10,
         fatalities=2,
@@ -13,6 +15,8 @@ data_conflict_event = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         event_type="civilian_targeting",
         events=3,
         fatalities=0,

--- a/tests/sample_data/data_food_security.py
+++ b/tests/sample_data/data_food_security.py
@@ -5,6 +5,8 @@ data_food_security = [
     dict(
         resource_hdx_id="62ad6e55-5f5d-4494-854c-4110687e9e25",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         ipc_phase="1",
         ipc_type="current",
         population_in_phase=500_000,
@@ -16,6 +18,8 @@ data_food_security = [
     dict(
         resource_hdx_id="62ad6e55-5f5d-4494-854c-4110687e9e25",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         ipc_phase="2",
         ipc_type="first projection",
         population_in_phase=40_000,
@@ -27,6 +31,8 @@ data_food_security = [
     dict(
         resource_hdx_id="62ad6e55-5f5d-4494-854c-4110687e9e25",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         ipc_phase="3",
         ipc_type="second projection",
         population_in_phase=3_000,

--- a/tests/sample_data/data_humanitarian_needs.py
+++ b/tests/sample_data/data_humanitarian_needs.py
@@ -5,6 +5,8 @@ data_humanitarian_needs = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         gender="all",
         age_range="all",
         disabled_marker="all",
@@ -19,6 +21,8 @@ data_humanitarian_needs = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         gender="f",
         age_range="all",
         disabled_marker="n",
@@ -33,6 +37,8 @@ data_humanitarian_needs = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         gender="f",
         age_range="0-4",
         min_age=0,
@@ -49,6 +55,8 @@ data_humanitarian_needs = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Provincia 03",
+        provider_admin2_name="Distrito D",
         gender="all",
         age_range="80+",
         min_age=80,

--- a/tests/sample_data/data_idps.py
+++ b/tests/sample_data/data_idps.py
@@ -4,6 +4,8 @@ data_idps = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         assessment_type="BA",
         reporting_round=18,
         population=25000,

--- a/tests/sample_data/data_operational_presence.py
+++ b/tests/sample_data/data_operational_presence.py
@@ -4,6 +4,8 @@ data_operational_presence = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         org_acronym="ORG01",
         org_name="Organisation 1",
         sector_code="SHL",
@@ -12,6 +14,8 @@ data_operational_presence = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         org_acronym="ORG02",
         org_name="Organisation 2",
         sector_code="FSC",
@@ -20,6 +24,8 @@ data_operational_presence = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         org_acronym="ORG03",
         org_name="Organisation 3",
         sector_code="WSH",
@@ -28,6 +34,8 @@ data_operational_presence = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=6,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         org_acronym="ORG03",
         org_name="Organisation 3",
         sector_code="HEA",
@@ -36,6 +44,8 @@ data_operational_presence = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         org_acronym="ORG02",
         org_name="Organisation 2",
         sector_code="WSH",

--- a/tests/sample_data/data_population.py
+++ b/tests/sample_data/data_population.py
@@ -5,6 +5,8 @@ data_population = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         gender="all",
         age_range="all",
         population=1_000_000,
@@ -15,6 +17,8 @@ data_population = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         gender="f",
         age_range="all",
         population=500_000,
@@ -25,6 +29,8 @@ data_population = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         gender="f",
         age_range="0-4",
         min_age=0,
@@ -37,6 +43,8 @@ data_population = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         gender="all",
         age_range="80+",
         min_age=80,

--- a/tests/sample_data/data_poverty_rate.py
+++ b/tests/sample_data/data_poverty_rate.py
@@ -3,7 +3,7 @@ from datetime import datetime
 data_poverty_rate = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
-        admin1_ref=1,
+        admin1_ref=2,
         provider_admin1_name="Provincia 01",
         mpi=0.617442,
         headcount_ratio=85.4,

--- a/tests/sample_data/data_poverty_rate.py
+++ b/tests/sample_data/data_poverty_rate.py
@@ -4,7 +4,7 @@ data_poverty_rate = [
     dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin1_ref=1,
-        admin1_name="Province 01",  # not p-coded/normalised yet
+        provider_admin1_name="Provincia 01",
         mpi=0.617442,
         headcount_ratio=85.4,
         intensity_of_deprivation=72.3,

--- a/tests/sample_data/data_wfp_market.py
+++ b/tests/sample_data/data_wfp_market.py
@@ -2,6 +2,8 @@ data_wfp_market = [
     dict(
         code="001",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         name="Market #1",
         lat=0.1,  # Foolandia is in the middle of the Gulf of Guinea :)
         lon=-0.1,

--- a/tests/test_conflict_event.py
+++ b/tests/test_conflict_event.py
@@ -19,6 +19,8 @@ def test_conflict_event_view(run_view_test):
         whereclause=(
             view_conflict_event.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
+            view_conflict_event.c.provider_admin1_name == "Provincia 01",
+            view_conflict_event.c.provider_admin2_name == "Distrito A",
             view_conflict_event.c.location_name == "Foolandia",
             view_conflict_event.c.admin1_name == "Province 01",
             view_conflict_event.c.admin2_name == "District A",
@@ -46,6 +48,8 @@ def _sample_data():
     return dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=4,
+        provider_admin1_name="Province 01",
+        provider_admin2_name="District A",
         event_type="political_violence",
         events=10,
         fatalities=2,

--- a/tests/test_food_price.py
+++ b/tests/test_food_price.py
@@ -17,6 +17,8 @@ def test_food_price_view(run_view_test):
         whereclause=(
             view_food_price.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
+            view_food_price.c.provider_admin1_name == "Provincia 01",
+            view_food_price.c.provider_admin2_name == "Distrito A",
             view_food_price.c.commodity_code == "001",
             view_food_price.c.currency_code == "FOO",
             view_food_price.c.price_flag == "actual",

--- a/tests/test_food_security.py
+++ b/tests/test_food_security.py
@@ -20,6 +20,8 @@ def test_food_security_view(run_view_test):
             view_food_security.c.resource_hdx_id
             == "62ad6e55-5f5d-4494-854c-4110687e9e25",
             view_food_security.c.admin2_code == "FOO-001-A",
+            view_food_security.c.provider_admin1_name == "Provincia 01",
+            view_food_security.c.provider_admin2_name == "Distrito A",
             view_food_security.c.admin1_code == "FOO-001",
             view_food_security.c.location_code == "FOO",
         ),
@@ -48,6 +50,8 @@ def test_reference_period_constraint(run_constraints_test):
             DBFoodSecurity(
                 resource_hdx_id="62ad6e55-5f5d-4494-854c-4110687e9e25",
                 admin2_ref=4,
+                provider_admin1_name="Provincia 01",
+                provider_admin2_name="Distrito A",
                 ipc_phase="1",
                 ipc_type="current",
                 population_in_phase=1_000,
@@ -67,6 +71,8 @@ def test_population_in_phase_positive(run_constraints_test):
             DBFoodSecurity(
                 resource_hdx_id="62ad6e55-5f5d-4494-854c-4110687e9e25",
                 admin2_ref=4,
+                provider_admin1_name="Provincia 01",
+                provider_admin2_name="Distrito A",
                 ipc_phase="1",
                 ipc_type="current",
                 population_in_phase=-1,

--- a/tests/test_funding.py
+++ b/tests/test_funding.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from hdx.database import Database
-from sqlalchemy.sql import null
 
 from hapi_schema.db_funding import (
     DBFunding,
@@ -39,8 +38,8 @@ def test_funding_availability(run_view_test):
             view_availability.c.category == "coordination-context",
             view_availability.c.subcategory == "funding",
             view_availability.c.location_code == "FOO",
-            view_availability.c.admin1_name == null(),
-            view_availability.c.admin2_name == null(),
+            view_availability.c.admin1_name == "",
+            view_availability.c.admin2_name == "",
             view_availability.c.hapi_updated_date == datetime(2023, 6, 1),
         ),
     )

--- a/tests/test_humanitarian_needs.py
+++ b/tests/test_humanitarian_needs.py
@@ -26,6 +26,10 @@ def test_humanitarian_needs_view(run_view_test):
         whereclause=(
             view_humanitarian_needs.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
+            view_humanitarian_needs.c.provider_admin1_name == "Provincia 01",
+            view_humanitarian_needs.c.provider_admin2_name == "Distrito B",
+            view_humanitarian_needs.c.provider_admin1_name == "Provincia 01",
+            view_humanitarian_needs.c.provider_admin2_name == "Distrito B",
             view_humanitarian_needs.c.admin2_code == "FOO-001-XXX",
             view_humanitarian_needs.c.admin1_code == "FOO-001",
             view_humanitarian_needs.c.location_code == "FOO",
@@ -59,6 +63,8 @@ def base_parameters():
     return dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         gender=Gender.ALL,
         age_range="-1-20",
         disabled_marker=DisabledMarker.ALL,

--- a/tests/test_idps.py
+++ b/tests/test_idps.py
@@ -19,6 +19,8 @@ def test_idps_view(run_view_test):
             view_idps.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
             view_idps.c.admin2_ref == 2,
+            view_idps.c.provider_admin1_name == "Provincia 01",
+            view_idps.c.provider_admin2_name == "Distrito B",
             view_idps.c.assessment_type == "BA",
             view_idps.c.reporting_round == 18,
             view_idps.c.population == 25000,
@@ -49,6 +51,8 @@ def base_parameters():
     return dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=2,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito B",
         assessment_type="BA",
         reporting_round=18,
         population=25000,

--- a/tests/test_national_risk.py
+++ b/tests/test_national_risk.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import pytest
 from hdx.database import Database
-from sqlalchemy.sql import null
 
 from hapi_schema.db_national_risk import (
     DBNationalRisk,
@@ -34,8 +33,8 @@ def test_national_risk_availability(run_view_test):
             view_availability.c.category == "coordination-context",
             view_availability.c.subcategory == "national-risk",
             view_availability.c.location_code == "FOO",
-            view_availability.c.admin1_name == null(),
-            view_availability.c.admin2_name == null(),
+            view_availability.c.admin1_name == "",
+            view_availability.c.admin2_name == "",
             view_availability.c.hapi_updated_date == datetime(2023, 6, 1),
         ),
     )

--- a/tests/test_operational_presence.py
+++ b/tests/test_operational_presence.py
@@ -19,6 +19,8 @@ def test_operational_presence_view(run_view_test):
         whereclause=(
             view_operational_presence.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
+            view_operational_presence.c.provider_admin1_name == "Provincia 01",
+            view_operational_presence.c.provider_admin2_name == "Distrito A",
             view_operational_presence.c.admin2_code == "FOO-XXX-XXX",
             view_operational_presence.c.admin1_code == "FOO-XXX",
             view_operational_presence.c.location_code == "FOO",
@@ -54,6 +56,8 @@ def test_reference_period_constraint(run_constraints_test):
             DBOperationalPresence(
                 resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
                 admin2_ref=2,
+                provider_admin1_name="Provincia 01",
+                provider_admin2_name="Distrito A",
                 org_acronym="ORG01",
                 org_name="Organisation 1",
                 sector_code="SHL",

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -16,6 +16,8 @@ def test_population_view(run_view_test):
         whereclause=(
             view_population.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
+            view_population.c.provider_admin1_name == "Provincia 01",
+            view_population.c.provider_admin2_name == "Distrito A",
             view_population.c.admin2_code == "FOO-001-XXX",
             view_population.c.admin1_code == "FOO-001",
             view_population.c.location_code == "FOO",
@@ -44,6 +46,8 @@ def base_parameters():
     return dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin2_ref=1,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         gender=Gender.ALL,
         age_range="all",
         population=1_000_000,

--- a/tests/test_poverty_rate.py
+++ b/tests/test_poverty_rate.py
@@ -21,6 +21,7 @@ def test_poverty_rate_view(run_view_test):
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
             view_poverty_rate.c.location_name == "Foolandia",
             view_poverty_rate.c.provider_admin1_name == "Provincia 01",
+            view_poverty_rate.c.admin1_name == "Province 01",
         ),
     )
 
@@ -33,7 +34,7 @@ def test_poverty_rate_availability(run_view_test):
             view_availability.c.category == "population-social",
             view_availability.c.subcategory == "poverty-rate",
             view_availability.c.location_code == "FOO",
-            view_availability.c.admin1_name == "Provincia 01",
+            view_availability.c.admin1_name == "Province 01",
             view_availability.c.hapi_updated_date == datetime(2023, 6, 1),
         ),
     )

--- a/tests/test_poverty_rate.py
+++ b/tests/test_poverty_rate.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from hdx.database import Database
-from sqlalchemy.sql import null
 
 from hapi_schema.db_poverty_rate import (
     DBPovertyRate,
@@ -21,7 +20,7 @@ def test_poverty_rate_view(run_view_test):
             view_poverty_rate.c.resource_hdx_id
             == "90deb235-1bf5-4bae-b231-3393222c2d01",
             view_poverty_rate.c.location_name == "Foolandia",
-            view_poverty_rate.c.admin1_name == "Province 01",
+            view_poverty_rate.c.provider_admin1_name == "Provincia 01",
         ),
     )
 
@@ -34,8 +33,7 @@ def test_poverty_rate_availability(run_view_test):
             view_availability.c.category == "population-social",
             view_availability.c.subcategory == "poverty-rate",
             view_availability.c.location_code == "FOO",
-            view_availability.c.admin1_name == "Province 01",
-            view_availability.c.admin2_name == null(),
+            view_availability.c.admin1_name == "Provincia 01",
             view_availability.c.hapi_updated_date == datetime(2023, 6, 1),
         ),
     )
@@ -118,7 +116,7 @@ def _sample_data():
     return dict(
         resource_hdx_id="90deb235-1bf5-4bae-b231-3393222c2d01",
         admin1_ref=1,
-        admin1_name="Province 02",
+        provider_admin1_name="Provincia 02",
         mpi=0.617442,
         headcount_ratio=85.4,
         intensity_of_deprivation=72.3,

--- a/tests/test_refugees.py
+++ b/tests/test_refugees.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from hdx.database import Database
-from sqlalchemy.sql import null
 
 from hapi_schema.db_refugees import (
     DBRefugees,
@@ -33,8 +32,8 @@ def test_refugees_availability(run_view_test):
             view_availability.c.subcategory == "refugees",
             view_availability.c.location_code
             == "BAR",  # we use the country of asylum, not origin
-            view_availability.c.admin1_name == null(),
-            view_availability.c.admin2_name == null(),
+            view_availability.c.admin1_name == "",
+            view_availability.c.admin2_name == "",
             view_availability.c.hapi_updated_date == datetime(2023, 8, 1),
         ),
     )

--- a/tests/test_returnees.py
+++ b/tests/test_returnees.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from hdx.database import Database
-from sqlalchemy.sql import null
 
 from hapi_schema.db_returnees import (
     DBReturnees,
@@ -33,8 +32,8 @@ def test_returnees_availability(run_view_test):
             view_availability.c.subcategory == "returnees",
             view_availability.c.location_code
             == "BAR",  # we use the country of asylum, not origin
-            view_availability.c.admin1_name == null(),
-            view_availability.c.admin2_name == null(),
+            view_availability.c.admin1_name == "",
+            view_availability.c.admin2_name == "",
             view_availability.c.hapi_updated_date == datetime(2023, 8, 1),
         ),
     )

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -499,6 +499,8 @@ def test_wfp_market_vat(
     """Check that wfp_market_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = ["code"]
     expected_indexes = [
+        "provider_admin1_name",
+        "provider_admin2_name",
         "name",
         "lat",
         "lon",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -122,6 +122,8 @@ def test_food_price_vat(
         "reference_period_start",
     ]
     expected_indexes = [
+        "provider_admin1_name",
+        "provider_admin2_name",
         "currency_code",
         "commodity_name",
         "market_name",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -386,7 +386,7 @@ def test_poverty_rate_vat(
     """Check that poverty_rate_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin1_ref",
-        "admin1_name",
+        "provider_admin1_name",
         "reference_period_start",
     ]
     expected_indexes = [
@@ -394,7 +394,6 @@ def test_poverty_rate_vat(
         "location_ref",
         "location_code",
         "location_name",
-        "admin1_name",
     ]
     run_columns_test(
         "poverty_rate_vat", "poverty_rate_view", view_params_poverty_rate

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -64,6 +64,8 @@ def test_conflict_event_vat(
     """Check that conflict_event_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
         "event_type",
         "reference_period_start",
     ]

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -148,6 +148,8 @@ def test_food_security_vat(
     """Check that food_security_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
         "ipc_type",
         "ipc_phase",
         "reference_period_start",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -192,6 +192,8 @@ def test_humanitarian_needs_vat(
     """Check that humanitarian_needs_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
         "gender",
         "age_range",
         "sector_code",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -353,12 +353,18 @@ def test_population_vat(
     run_indexes_test, run_columns_test, run_primary_keys_test
 ):
     """Check that population_vat is correct - columns match, expected indexes present"""
-    expected_primary_keys = ["admin2_ref", "gender", "age_range"]
+    expected_primary_keys = [
+        "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
+        "gender",
+        "age_range",
+        "reference_period_start",
+    ]
     expected_indexes = [
         "min_age",
         "max_age",
         "population",
-        "reference_period_start",
         "reference_period_end",
         "location_code",
         "location_name",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -285,6 +285,8 @@ def test_operational_presence_vat(
     """Check that operational_presence_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
         "org_acronym",
         "org_name",
         "sector_code",

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -224,6 +224,8 @@ def test_idps_vat(run_indexes_test, run_columns_test, run_primary_keys_test):
     """Check that funding_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
         "admin2_ref",
+        "provider_admin1_name",
+        "provider_admin2_name",
         "assessment_type",
         "reference_period_start",
     ]

--- a/tests/test_wfp_market.py
+++ b/tests/test_wfp_market.py
@@ -12,6 +12,8 @@ def test_wfp_market_view(run_view_test):
     run_view_test(
         view=view_wfp_market,
         whereclause=(
+            view_wfp_market.c.provider_admin1_name == "Provincia 01",
+            view_wfp_market.c.provider_admin2_name == "Distrito A",
             view_wfp_market.c.code == "001",
             view_wfp_market.c.name == "Market #1",
             view_wfp_market.c.lat == 0.1,
@@ -55,6 +57,8 @@ def _sample_data():
     return dict(
         code="001",
         admin2_ref=4,
+        provider_admin1_name="Provincia 01",
+        provider_admin2_name="Distrito A",
         name="Market #1",
         lat=0.1,
         lon=-0.1,


### PR DESCRIPTION
**This is a major, backwards-incompatible refactoring of the database, so we have to proceed carefully.**

Add the fields `provider\_admin1\_name` and `provider\_admin2\_name` to all appropriate subcategory tables, and make them part of the primary keys.

The pipelines should always put the providers' spellings of the admin1 and admin2 names into these fields.  These fields must be filled with something.

When source data can't be p-coded, `admin2\_ref` or `admin1\_ref` should point to the _unspecified_ placeholder.

For the `population` table, there is a small workaround in the `data\_availability\_view`, using the provider\_admin1\_name temporarily until we start p-coding the lat/lon.

All VATs and associated tests are updated.