### PR TITLE
HDX-10241 Update VAT definitions to match Alembic migration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ src/hapi_schema/_version.py
 
 # OS Files
 *DS_Store
+
+src/hapi_schema/utils/db_views_for_hapi.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -79,10 +79,10 @@ class DBConflictEventVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     event_type: Mapped[EventType] = mapped_column(
         build_enum_using_values(EventType), primary_key=True
@@ -181,10 +181,10 @@ class DBFoodSecurityVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     ipc_phase: Mapped[IPCPhase] = mapped_column(
         build_enum_using_values(IPCPhase), primary_key=True
@@ -244,10 +244,10 @@ class DBHumanitarianNeedsVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     category: Mapped[str] = mapped_column(String(128), primary_key=True)
     sector_code: Mapped[str] = mapped_column(String(32), primary_key=True)
@@ -283,10 +283,10 @@ class DBIDPsVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     assessment_type: Mapped[str] = mapped_column(String(32), primary_key=True)
     reporting_round: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -365,10 +365,10 @@ class DBOperationalPresenceVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     org_acronym: Mapped[str] = mapped_column(String, primary_key=True)
     org_name: Mapped[str] = mapped_column(String, primary_key=True)
@@ -419,10 +419,10 @@ class DBPopulationVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin2_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     provider_admin2_name: Mapped[str] = mapped_column(
-        String(512), primary_key=True
+        String(512), primary_key=True, index=True
     )
     gender: Mapped[Gender] = mapped_column(
         build_enum_using_values(Gender), primary_key=True
@@ -432,7 +432,7 @@ class DBPopulationVAT(Base):
     max_age: Mapped[int] = mapped_column(Integer, nullable=True, index=True)
     population: Mapped[int] = mapped_column(Integer, index=True)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        DateTime, primary_key=True, index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
         DateTime,
@@ -458,8 +458,7 @@ class DBPovertyRateVAT(Base):
     resource_hdx_id: Mapped[str] = mapped_column(String(36))
     admin1_ref: Mapped[int] = mapped_column(Integer, primary_key=True)
     provider_admin1_name: Mapped[str] = mapped_column(
-        String(512),
-        primary_key=True,
+        String(512), primary_key=True, index=True
     )
     mpi: Mapped[float] = mapped_column(Float)
     headcount_ratio: Mapped[float] = mapped_column(Float)
@@ -467,7 +466,7 @@ class DBPovertyRateVAT(Base):
     vulnerable_to_poverty: Mapped[float] = mapped_column(Float)
     in_severe_poverty: Mapped[float] = mapped_column(Float)
     reference_period_start: Mapped[datetime] = mapped_column(
-        DateTime, primary_key=True
+        DateTime, primary_key=True, index=True
     )
     reference_period_end: Mapped[datetime] = mapped_column(
         DateTime,
@@ -478,7 +477,7 @@ class DBPovertyRateVAT(Base):
     location_name: Mapped[str] = mapped_column(String(512), index=True)
     has_hrp: Mapped[bool] = mapped_column(Boolean)
     in_gho: Mapped[bool] = mapped_column(Boolean)
-    admin1_name: Mapped[str] = mapped_column(String(512))
+    admin1_name: Mapped[str] = mapped_column(String(512), index=True)
     admin1_code: Mapped[str] = mapped_column(String(128))
     admin1_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     location_ref: Mapped[int] = mapped_column(Integer, index=True)

--- a/src/hapi_schema/utils/hapi_views_code_generator.py
+++ b/src/hapi_schema/utils/hapi_views_code_generator.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-This script is designed to generate view tables to go in the hdx-hapi repo.
+This script is designed to generate view tables to go in the hdx-hapi repo. The test database
+docker container needs to be started and initialised for this code to run.
 
 The code is configured using the `view_as_table_definitions.toml` file and then with an invocation like:
 
-`./hapi_views_code_generator.py`
+`./hapi_views_code_generator.py wfp_commodity_view`
+
+or
+
+`./hapi_views_code_generator.py all`
 
 The assumption is that the view_as_table_definitions.toml file will have been edited appropriately when generating the
 "views as table". This script generates the imports, setups and classes for all views in a single run - they
-can be piped to a file
+can be piped to a file or a single view
 
 Ian Hopkinson 2024-05-09
 """
@@ -87,7 +92,6 @@ def parse_toml():
             complete_code.extend(table_code)
         elif table["target_view"] == target_view:
             complete_code = create_table_code(table, target_view)
-            complete_code.extend(table_code)
 
     for line in complete_code:
         print(line, flush=True)

--- a/src/hapi_schema/utils/view_as_table_code_generator.py
+++ b/src/hapi_schema/utils/view_as_table_code_generator.py
@@ -7,7 +7,9 @@ The code is configured using the `view_as_table_definitions.toml` file and then 
 
 `./view_as_table_code_generator.py patch_view`
 
-This will pick up the appropriate section from the toml file
+This will pick up the appropriate section from the toml file.
+
+These go in the src\hapi_schema\db_views_as_tables.py file
 
 Ian Hopkinson 2024-05-09
 """

--- a/src/hapi_schema/utils/view_as_table_definitions.toml
+++ b/src/hapi_schema/utils/view_as_table_definitions.toml
@@ -227,3 +227,35 @@ view_params_name="view_params_patch"
 expected_primary_keys = ["id"]
 expected_indexes = ["patch_sequence_number", "patch_path", "state", "execution_date"]
 expected_nullables = []
+
+[[tables]]
+db_module = "db_idps"
+target_view = "idps_view"
+view_params_name="view_params_idps"
+expected_primary_keys = [
+        "admin2_ref",
+        "assessment_type",
+        "population",
+        "reference_period_start",
+        "reference_period_end",
+    ]
+expected_indexes = ["events", "fatalities", "reference_period_end", "location_code",
+"location_name", "admin1_code", "admin1_name", "admin2_code", "admin2_name"]
+expected_nullables = ["reporting_round", "reference_period_end"]
+
+[[tables]]
+db_module = "db_returnees"
+target_view = "returnees_view"
+view_params_name="view_params_returnees"
+expected_primary_keys = [
+        "origin_location_ref",
+        "asylum_location_ref",
+        "population_group",
+        "gender",
+        "age_range",
+        "reference_period_start"
+    ]
+expected_indexes = ["min_age", "max_age", "population", "reference_period_end",
+                    "origin_location_code", "origin_location_name",
+                    "asylum_location_code", "asylum_location_name"]
+expected_nullables = ["min_age", "max_age"]

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -79,6 +79,8 @@ def test_conflict_event_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test(
         "conflict_event_vat", "conflict_event_view", view_params_conflict_event
@@ -166,6 +168,8 @@ def test_food_security_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test(
         "food_security_vat", "food_security_view", view_params_food_security
@@ -213,6 +217,8 @@ def test_humanitarian_needs_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test(
         "humanitarian_needs_vat",
@@ -243,6 +249,8 @@ def test_idps_vat(run_indexes_test, run_columns_test, run_primary_keys_test):
         "admin1_code",
         "admin2_name",
         "admin2_code",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test("idps_vat", "idps_view", view_params_idps)
     run_primary_keys_test("idps_vat", expected_primary_keys)
@@ -304,6 +312,8 @@ def test_operational_presence_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test(
         "operational_presence_vat",
@@ -364,6 +374,7 @@ def test_population_vat(
         "min_age",
         "max_age",
         "population",
+        "reference_period_start",
         "reference_period_end",
         "location_code",
         "location_name",
@@ -371,6 +382,8 @@ def test_population_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "provider_admin1_name",
+        "provider_admin2_name",
     ]
     run_columns_test(
         "population_vat", "population_view", view_params_population
@@ -389,10 +402,13 @@ def test_poverty_rate_vat(
         "reference_period_start",
     ]
     expected_indexes = [
+        "reference_period_start",
         "reference_period_end",
         "location_ref",
         "location_code",
         "location_name",
+        "admin1_name",
+        "provider_admin1_name",
     ]
     run_columns_test(
         "poverty_rate_vat", "poverty_rate_view", view_params_poverty_rate


### PR DESCRIPTION
In preparing Alembic migration scripts for the provider name change we noticed some inconsistencies in the primary key/index settings. This PR resolves those consistencies, or at least those that were apparent 

One philosophical change is that we explicitly index the provider_admin1_name and provider_admin2_name columns. They typically belong to the primary key and are thus indexed, however the primary keys are composite and so search performance is not improved without explicitly indexing  the column.