### PR TITLE
PR HDX-10413 indices for data_availability_vat + indices for admin_level

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6
+
+### Fixed
+
+- Fixed data_availability_vat primary key and indices
+- Added indices for each new admin_level column in other tables
+
 ## 0.9.5
 
 ### Changed

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -109,7 +109,7 @@ class DBConflictEventVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBCurrencyVAT(Base):
@@ -175,7 +175,7 @@ class DBFoodPriceVAT(Base):
     admin2_code: Mapped[str] = mapped_column(String(128), index=True)
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBFoodSecurityVAT(Base):
@@ -216,7 +216,7 @@ class DBFoodSecurityVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBFundingVAT(Base):
@@ -279,7 +279,7 @@ class DBHumanitarianNeedsVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBIDPsVAT(Base):
@@ -316,7 +316,7 @@ class DBIDPsVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBLocationVAT(Base):
@@ -401,7 +401,7 @@ class DBOperationalPresenceVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBOrgTypeVAT(Base):
@@ -457,7 +457,7 @@ class DBPopulationVAT(Base):
     admin2_name: Mapped[str] = mapped_column(String(512), index=True)
     admin2_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     admin1_ref: Mapped[int] = mapped_column(Integer)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBPovertyRateVAT(Base):
@@ -489,7 +489,7 @@ class DBPovertyRateVAT(Base):
     admin1_code: Mapped[str] = mapped_column(String(128))
     admin1_is_unspecified: Mapped[bool] = mapped_column(Boolean)
     location_ref: Mapped[int] = mapped_column(Integer, index=True)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
 
 
 class DBRefugeesVAT(Base):
@@ -622,13 +622,14 @@ class DBWfpMarketVAT(Base):
 
 class DBAvailabilityVAT(Base):
     __tablename__ = "data_availability_vat"
-    category: Mapped[str] = mapped_column(String(128), primary_key=True)
-    subcategory: Mapped[str] = mapped_column(String(128), primary_key=True)
-    location_name: Mapped[str] = mapped_column(String(512), primary_key=True)
-    location_code: Mapped[str] = mapped_column(String(128), primary_key=True)
-    admin1_name: Mapped[str] = mapped_column(String(512), primary_key=True)
-    admin1_code: Mapped[str] = mapped_column(String(128), primary_key=True)
-    admin2_name: Mapped[str] = mapped_column(String(512), primary_key=True)
-    admin2_code: Mapped[str] = mapped_column(String(128), primary_key=True)
-    admin_level: Mapped[int] = mapped_column(Integer)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    category: Mapped[str] = mapped_column(String(128), index=True)
+    subcategory: Mapped[str] = mapped_column(String(128), index=True)
+    location_name: Mapped[str] = mapped_column(String(512), index=True)
+    location_code: Mapped[str] = mapped_column(String(128), index=True)
+    admin1_name: Mapped[str] = mapped_column(String(512), index=True)
+    admin1_code: Mapped[str] = mapped_column(String(128), index=True)
+    admin2_name: Mapped[str] = mapped_column(String(512), index=True)
+    admin2_code: Mapped[str] = mapped_column(String(128), index=True)
+    admin_level: Mapped[int] = mapped_column(Integer, index=True)
     hapi_updated_date: Mapped[datetime] = mapped_column(DateTime, index=True)

--- a/src/hapi_schema/db_views_as_tables.py
+++ b/src/hapi_schema/db_views_as_tables.py
@@ -622,7 +622,9 @@ class DBWfpMarketVAT(Base):
 
 class DBAvailabilityVAT(Base):
     __tablename__ = "data_availability_vat"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True
+    )
     category: Mapped[str] = mapped_column(String(128), index=True)
     subcategory: Mapped[str] = mapped_column(String(128), index=True)
     location_name: Mapped[str] = mapped_column(String(512), index=True)

--- a/tests/test_views_as_tables.py
+++ b/tests/test_views_as_tables.py
@@ -79,6 +79,7 @@ def test_conflict_event_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "conflict_event_vat", "conflict_event_view", view_params_conflict_event
@@ -136,6 +137,7 @@ def test_food_price_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "food_price_vat", "food_price_view", view_params_food_price
@@ -166,6 +168,7 @@ def test_food_security_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "food_security_vat", "food_security_view", view_params_food_security
@@ -213,6 +216,7 @@ def test_humanitarian_needs_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "humanitarian_needs_vat",
@@ -243,6 +247,7 @@ def test_idps_vat(run_indexes_test, run_columns_test, run_primary_keys_test):
         "admin1_code",
         "admin2_name",
         "admin2_code",
+        "admin_level",
     ]
     run_columns_test("idps_vat", "idps_view", view_params_idps)
     run_primary_keys_test("idps_vat", expected_primary_keys)
@@ -304,6 +309,7 @@ def test_operational_presence_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "operational_presence_vat",
@@ -371,6 +377,7 @@ def test_population_vat(
         "admin1_name",
         "admin2_code",
         "admin2_name",
+        "admin_level",
     ]
     run_columns_test(
         "population_vat", "population_view", view_params_population
@@ -393,6 +400,7 @@ def test_poverty_rate_vat(
         "location_ref",
         "location_code",
         "location_name",
+        "admin_level",
     ]
     run_columns_test(
         "poverty_rate_vat", "poverty_rate_view", view_params_poverty_rate
@@ -522,6 +530,9 @@ def test_wfp_market_vat(
 def test_data_availability_vat(run_indexes_test, run_primary_keys_test):
     """Check that wfp_market_vat is correct - columns match, expected indexes present"""
     expected_primary_keys = [
+        "id",
+    ]
+    expected_indexes = [
         "category",
         "subcategory",
         "location_name",
@@ -530,8 +541,7 @@ def test_data_availability_vat(run_indexes_test, run_primary_keys_test):
         "admin1_code",
         "admin2_name",
         "admin2_code",
-    ]
-    expected_indexes = [
+        "admin_level",
         "hapi_updated_date",
     ]
     #    run_columns_test(


### PR DESCRIPTION
The `data_availability_vat` table had a primary key that did not include the new "admin_level". This was causing unique constraint violations when trying to import humanitarian needs values.
I removed the primary key altogether because I don't think it was serving any purpose in the HAPI db and replaced it with a dummy (autoincrementing) one so that sqlAlchemy/alembic don't complain.  Also added indices for the other columns that can be used as filters.

Added indices for each new `admin_level` column in the other tables. If we switch the HAPI `admin_level` filter to use these new columns they should have indices.